### PR TITLE
Create Rust project structure for Z-Machine Mark 2 VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@ For generating output, the VM may similarly initiate asynchronous NLG requests t
 Once the LLM generates descriptive text, the VM retrieves it and combines it with its own direct output, presenting the full narrative to the Player.
 
 This asynchronous model is crucial for maintaining a responsive user experience despite potential LLM latency.
+
+## Repository Contents
+
+This repository contains the design specification and the Rust implementation of the Z-Machine Mark 2 Virtual Machine.
+
+*   **`ZMACHINE_MARK_2_DESIGN_SPEC.md`**: The detailed design document for the Z-Machine Mark 2.
+*   **`zm2_vm/`**: A Rust Cargo project that implements the Z-Machine Mark 2 virtual machine as a library. This crate will contain the core logic for the VM, including memory management, opcode execution, and LLM integration, as outlined in the design specification.
+
+Further details about the `zm2_vm` crate can be found within its own documentation once developed.

--- a/zm2_vm/Cargo.toml
+++ b/zm2_vm/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "zm2_vm"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/zm2_vm/src/lib.rs
+++ b/zm2_vm/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
This commit introduces the initial Rust Cargo project for the Z-Machine Mark 2 Virtual Machine (`zm2_vm`).

- A new library crate `zm2_vm` has been created.
- The main `README.md` has been updated to include a section describing the contents of this repository, specifically mentioning the new `zm2_vm` crate and its purpose as defined in the `ZMACHINE_MARK_2_DESIGN_SPEC.md`.
- The `.gitignore` file was checked and confirmed to include necessary patterns for Rust/Cargo projects, such as the `/target` directory, to exclude build artifacts from the repository.